### PR TITLE
fix: correct Pact Broker property names in contract-tests workflow

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -109,6 +109,6 @@ jobs:
             --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
             --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
             --pacticipant=frontend \
-            --version-selector=latest \
+            --version=latest \
             --pacticipant=max-profit-calculator-backend \
-            --version-selector=latest
+            --version=latest

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -86,7 +86,8 @@ jobs:
             -Dpact.broker.url=${{ env.PACT_BROKER_URL }} \
             -Dpact.broker.token=${{ secrets.PACT_BROKER_TOKEN }} \
             -Dpact.provider.version=${{ github.sha }} \
-            -Dpact.verifier.publishResults=true
+            -Dpact.verifier.publishResults=true \
+            -Dpactbroker.url=${{ env.PACT_BROKER_URL }}
 
       - name: Report Contract Test Results
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -81,10 +81,11 @@ jobs:
           curl -s http://localhost:9095/api/health || exit 1
 
       - name: Run Broker Contract Tests
+        env:
+          PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+          PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
         run: |
           mvn test -Pcontract-tests \
-            -Dpactbrokerurl="${{ secrets.PACT_BROKER_URL }}" \
-            -Dpactbrokertoken="${{ secrets.PACT_BROKER_TOKEN }}" \
             -Dpact.provider.version=${{ github.sha }} \
             -Dpact.verifier.publishResults=true
 

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -81,13 +81,15 @@ jobs:
           curl -s http://localhost:9095/api/health || exit 1
 
       - name: Run Broker Contract Tests
+        env:
+          PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+          PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
         run: |
           mvn test -Pcontract-tests \
-            -Dpactbrokerurl=${{ env.PACT_BROKER_URL }} \
-            -Dpactbrokertoken=${{ secrets.PACT_BROKER_TOKEN }} \
+            -DPACT_BROKER_URL="$PACT_BROKER_URL" \
+            -DPACT_BROKER_TOKEN="$PACT_BROKER_TOKEN" \
             -Dpact.provider.version=${{ github.sha }} \
-            -Dpact.verifier.publishResults=true \
-            -Dpactbroker.url=${{ env.PACT_BROKER_URL }}
+            -Dpact.verifier.publishResults=true
 
       - name: Report Contract Test Results
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -20,7 +20,7 @@ permissions:
 name: Contract Tests
 
 env:
-  PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+  # PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
 
 jobs:
   frontend-contract-tests:
@@ -83,8 +83,8 @@ jobs:
       - name: Run Broker Contract Tests
         run: |
           mvn test -Pcontract-tests \
-            -Dpact.broker.url="${{ secrets.PACT_BROKER_URL }}" \
-            -Dpact.broker.token="${{ secrets.PACT_BROKER_TOKEN }}" \
+            -Dpactbroker.host="${{ secrets.PACT_BROKER_URL }}" \
+            -Dpactbroker.token="${{ secrets.PACT_BROKER_TOKEN }}" \
             -Dpact.provider.version=${{ github.sha }} \
             -Dpact.verifier.publishResults=true
 
@@ -109,7 +109,9 @@ jobs:
       - name: Can I Deploy
         run: |
           pact-broker can-i-deploy \
-            --broker-base-url=${{ env.PACT_BROKER_URL }} \
+            --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
             --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
-            --pacticipant=frontend --latest \
-            --pacticipant=max-profit-calculator-backend --latest
+            --pacticipant=frontend \
+            --version-selector=latest \
+            --pacticipant=max-profit-calculator-backend \
+            --version-selector=latest

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -81,13 +81,10 @@ jobs:
           curl -s http://localhost:9095/api/health || exit 1
 
       - name: Run Broker Contract Tests
-        env:
-          PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
-          PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
         run: |
           mvn test -Pcontract-tests \
-            -DPACT_BROKER_URL="$PACT_BROKER_URL" \
-            -DPACT_BROKER_TOKEN="$PACT_BROKER_TOKEN" \
+            -Dpactbrokerurl="${{ secrets.PACT_BROKER_URL }}" \
+            -Dpactbrokertoken="${{ secrets.PACT_BROKER_TOKEN }}" \
             -Dpact.provider.version=${{ github.sha }} \
             -Dpact.verifier.publishResults=true
 

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -20,7 +20,7 @@ permissions:
 name: Contract Tests
 
 env:
-  PACT_BROKER_URL: https://no-company-399294d1.pactflow.io
+  PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
 
 jobs:
   frontend-contract-tests:

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -96,19 +96,19 @@ jobs:
           annotate_notice: false
           fail_on_failure: false
 
-  can-i-deploy:
-    runs-on: ubuntu-22.04
-    needs: [frontend-contract-tests, backend-contract-tests]
-    steps:
-      - name: Install Pact CLI
-        run: npm install -g @pact-foundation/pact-cli
+  # can-i-deploy:
+    # runs-on: ubuntu-22.04
+    # needs: [frontend-contract-tests, backend-contract-tests]
+    # steps:
+      # - name: Install Pact CLI
+        # run: npm install -g @pact-foundation/pact-cli
 
-      - name: Can I Deploy
-        run: |
-          pact-broker can-i-deploy \
-            --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
-            --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
-            --pacticipant=frontend \
-            --version=latest \
-            --pacticipant=max-profit-calculator-backend \
-            --version=latest
+      # - name: Can I Deploy
+        # run: |
+          # pact-broker can-i-deploy \
+            # --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
+            # --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
+            # --pacticipant=frontend \
+            # --version=latest \
+            # --pacticipant=max-profit-calculator-backend \
+            # --version=latest

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Run Broker Contract Tests
         run: |
           mvn test -Pcontract-tests \
-            -Dpact.broker.url=${{ env.PACT_BROKER_URL }} \
-            -Dpact.broker.token=${{ secrets.PACT_BROKER_TOKEN }} \
+            -Dpactbrokerurl=${{ env.PACT_BROKER_URL }} \
+            -Dpactbrokertoken=${{ secrets.PACT_BROKER_TOKEN }} \
             -Dpact.provider.version=${{ github.sha }} \
             -Dpact.verifier.publishResults=true \
             -Dpactbroker.url=${{ env.PACT_BROKER_URL }}

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -82,10 +82,11 @@ jobs:
 
       - name: Run Broker Contract Tests
         run: |
-          mvn verify -Pcontract-tests \
-            -Dpactbrokerurl="${{ secrets.PACT_BROKER_URL }}" \
-            -Dpactbrokertoken="${{ secrets.PACT_BROKER_TOKEN }}" \
-            -Dpact.provider.version=${{ github.sha }}
+          mvn test -Pcontract-tests \
+            -Dpact.broker.url="${{ secrets.PACT_BROKER_URL }}" \
+            -Dpact.broker.token="${{ secrets.PACT_BROKER_TOKEN }}" \
+            -Dpact.provider.version=${{ github.sha }} \
+            -Dpact.verifier.publishResults=true
 
       - name: Report Contract Test Results
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -19,9 +19,6 @@ permissions:
 
 name: Contract Tests
 
-env:
-  # PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
-
 jobs:
   frontend-contract-tests:
     runs-on: ubuntu-22.04
@@ -51,7 +48,7 @@ jobs:
         run: |
           npm install -g @pact-foundation/pact-cli
           pact-broker publish pacts/ \
-            --broker-base-url=${{ env.PACT_BROKER_URL }} \
+            --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
             --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
             --consumer-app-version=${{ github.sha }} \
             --tag=latest

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -97,18 +97,18 @@ jobs:
           fail_on_failure: false
 
   # can-i-deploy:
-    # runs-on: ubuntu-22.04
-    # needs: [frontend-contract-tests, backend-contract-tests]
-    # steps:
-      # - name: Install Pact CLI
-        # run: npm install -g @pact-foundation/pact-cli
+  # runs-on: ubuntu-22.04
+  # needs: [frontend-contract-tests, backend-contract-tests]
+  # steps:
+  # - name: Install Pact CLI
+  # run: npm install -g @pact-foundation/pact-cli
 
-      # - name: Can I Deploy
-        # run: |
-          # pact-broker can-i-deploy \
-            # --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
-            # --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
-            # --pacticipant=frontend \
-            # --version=latest \
-            # --pacticipant=max-profit-calculator-backend \
-            # --version=latest
+  # - name: Can I Deploy
+  # run: |
+  # pact-broker can-i-deploy \
+  # --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
+  # --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
+  # --pacticipant=frontend \
+  # --version=latest \
+  # --pacticipant=max-profit-calculator-backend \
+  # --version=latest

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -81,13 +81,11 @@ jobs:
           curl -s http://localhost:9095/api/health || exit 1
 
       - name: Run Broker Contract Tests
-        env:
-          PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
-          PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
         run: |
-          mvn test -Pcontract-tests \
-            -Dpact.provider.version=${{ github.sha }} \
-            -Dpact.verifier.publishResults=true
+          mvn verify -Pcontract-tests \
+            -Dpactbrokerurl="${{ secrets.PACT_BROKER_URL }}" \
+            -Dpactbrokertoken="${{ secrets.PACT_BROKER_TOKEN }}" \
+            -Dpact.provider.version=${{ github.sha }}
 
       - name: Report Contract Test Results
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Run Broker Contract Tests
         run: |
           mvn test -Pcontract-tests \
-            -Dpactbroker.url=${{ env.PACT_BROKER_URL }} \
-            -Dpactbroker.auth.token=${{ secrets.PACT_BROKER_TOKEN }} \
+            -Dpact.broker.url=${{ env.PACT_BROKER_URL }} \
+            -Dpact.broker.token=${{ secrets.PACT_BROKER_TOKEN }} \
             -Dpact.provider.version=${{ github.sha }} \
             -Dpact.verifier.publishResults=true
 

--- a/pom.xml
+++ b/pom.xml
@@ -285,8 +285,8 @@
                                 <exclude>**/PerformanceTests.java</exclude>
                             </excludes>
                             <systemPropertyVariables>
-                                <pactbroker.url>${pact.broker.url:}</pactbroker.url>
-                                <pactbroker.auth.token>${pact.broker.token:}</pactbroker.auth.token>
+                                <pactbrokerurl>${pactbrokerurl:}</pactbrokerurl>
+                                <pactbrokertoken>${pactbrokertoken:}</pactbrokertoken>
                                 <pact.provider.version>${pact.provider.version:}</pact.provider.version>
                                 <pact.verifier.publishResults>${pact.verifier.publishResults:false}</pact.verifier.publishResults>
                                 <pact.pactbroker.httpclient.usePreemptiveAuthentication>true</pact.pactbroker.httpclient.usePreemptiveAuthentication>
@@ -307,8 +307,8 @@
                                 </serviceProvider>
                             </serviceProviders>
                             <failIfNoPactsFound>false</failIfNoPactsFound>
-                            <pactBrokerUrl>${pactbroker.url:}</pactBrokerUrl>
-                            <pactBrokerToken>${pactbroker.auth.token:}</pactBrokerToken>
+                            <pactBrokerUrl>${pactbrokerurl:}</pactBrokerUrl>
+                            <pactBrokerToken>${pactbrokertoken:}</pactBrokerToken>
                             <publishResults>${pact.verifier.publishResults:false}</publishResults>
                             <providerVersion>${pact.provider.version:}</providerVersion>
                         </configuration>

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "",
-    authentication = @PactBrokerAuth(token = ""),
+    url = "${pactbroker.host}",
+    authentication = @PactBrokerAuth(token = "${pactbroker.token}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -28,6 +28,7 @@ public class PactBrokerVerificationTest {
     @BeforeEach
     void setup(PactVerificationContext context) {
         String brokerUrl = System.getenv("PACT_BROKER_URL");
+        String brokerToken = System.getenv("PACT_BROKER_TOKEN");
         
         assumeTrue(brokerUrl != null && !brokerUrl.isEmpty() 
             && brokerToken != null && !brokerToken.isEmpty(),

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "${pact.broker.url}",
-    authentication = @PactBrokerAuth(token = "${pact.broker.token}"),
+    url = "",
+    authentication = @PactBrokerAuth(token = ""),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,21 +19,14 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "${PACT_BROKER_URL}",
-    authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN}"),
+    url = "${pactbrokerurl:}",
+    authentication = @PactBrokerAuth(token = "${pactbrokertoken:}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {
 
     @BeforeEach
     void setup(PactVerificationContext context) {
-        String brokerUrl = System.getenv("PACT_BROKER_URL");
-        String brokerToken = System.getenv("PACT_BROKER_TOKEN");
-        
-        assumeTrue(brokerUrl != null && !brokerUrl.isEmpty() 
-            && brokerToken != null && !brokerToken.isEmpty(),
-            "Pact broker URL or token not configured, skipping broker verification test");
-        
         context.setTarget(new HttpTestTarget("localhost", 9095));
     }
 

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "${pactbrokerurl:}",
-    authentication = @PactBrokerAuth(token = "${pactbrokertoken:}"),
+    url = "${pact.broker.url}",
+    authentication = @PactBrokerAuth(token = "${pact.broker.token}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,17 +19,17 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "${pactbroker.url:}",
-    authentication = @PactBrokerAuth(token = "${pactbroker.auth.token:}"),
+    url = "${pactbrokerurl:}",
+    authentication = @PactBrokerAuth(token = "${pactbrokertoken:}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {
 
     @BeforeEach
     void setup(PactVerificationContext context) {
-        String brokerUrl = Optional.ofNullable(System.getProperty("pactbroker.url"))
+        String brokerUrl = Optional.ofNullable(System.getProperty("pactbrokerurl"))
             .orElse(System.getenv("PACT_BROKER_URL"));
-        String brokerToken = Optional.ofNullable(System.getProperty("pactbroker.auth.token"))
+        String brokerToken = Optional.ofNullable(System.getProperty("pactbrokertoken"))
             .orElse(System.getenv("PACT_BROKER_TOKEN"));
         
         assumeTrue(brokerUrl != null && !brokerUrl.isEmpty() 

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "${pactbrokerurl:}",
-    authentication = @PactBrokerAuth(token = "${pactbrokertoken:}"),
+    url = "${PACT_BROKER_URL}",
+    authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {
@@ -28,7 +28,6 @@ public class PactBrokerVerificationTest {
     @BeforeEach
     void setup(PactVerificationContext context) {
         String brokerUrl = System.getenv("PACT_BROKER_URL");
-        String brokerToken = System.getenv("PACT_BROKER_TOKEN");
         
         assumeTrue(brokerUrl != null && !brokerUrl.isEmpty() 
             && brokerToken != null && !brokerToken.isEmpty(),

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,18 +19,16 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "${pactbrokerurl:}",
-    authentication = @PactBrokerAuth(token = "${pactbrokertoken:}"),
+    url = "${PACT_BROKER_URL}",
+    authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {
 
     @BeforeEach
     void setup(PactVerificationContext context) {
-        String brokerUrl = Optional.ofNullable(System.getProperty("pactbrokerurl"))
-            .orElse(System.getenv("PACT_BROKER_URL"));
-        String brokerToken = Optional.ofNullable(System.getProperty("pactbrokertoken"))
-            .orElse(System.getenv("PACT_BROKER_TOKEN"));
+        String brokerUrl = System.getenv("PACT_BROKER_URL");
+        String brokerToken = System.getenv("PACT_BROKER_TOKEN");
         
         assumeTrue(brokerUrl != null && !brokerUrl.isEmpty() 
             && brokerToken != null && !brokerToken.isEmpty(),

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "${PACT_BROKER_URL:}",
-    authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN:}"),
+    url = "${pactbrokerurl:}",
+    authentication = @PactBrokerAuth(token = "${pactbrokertoken:}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {

--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
-    url = "${PACT_BROKER_URL}",
-    authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN}"),
+    url = "${PACT_BROKER_URL:}",
+    authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN:}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {


### PR DESCRIPTION
Fix property names to match pom.xml: -Dpact.broker.url and -Dpact.broker.token