### PR TITLE
Enable can-i-deploy compatibility check

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -96,19 +96,21 @@ jobs:
           annotate_notice: false
           fail_on_failure: false
 
-  # can-i-deploy:
-  # runs-on: ubuntu-22.04
-  # needs: [frontend-contract-tests, backend-contract-tests]
-  # steps:
-  # - name: Install Pact CLI
-  # run: npm install -g @pact-foundation/pact-cli
+  can-i-deploy:
+    runs-on: ubuntu-22.04
+    needs: [frontend-contract-tests, backend-contract-tests]
+    steps:
+      - name: Install Pact CLI
+        run: npm install -g @pact-foundation/pact-cli
 
-  # - name: Can I Deploy
-  # run: |
-  # pact-broker can-i-deploy \
-  # --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
-  # --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
-  # --pacticipant=frontend \
-  # --version=latest \
-  # --pacticipant=max-profit-calculator-backend \
-  # --version=latest
+      # Check if the latest versions of all pacticipants are mutually compatible
+      # This is a "can I merge" check without recording any deployment
+      - name: Can I Deploy (Compatibility Check)
+        run: |
+          pact broker can-i-deploy \
+            --broker-base-url=${{ secrets.PACT_BROKER_URL }} \
+            --broker-token=${{ secrets.PACT_BROKER_TOKEN }} \
+            --pacticipant frontend \
+            --latest \
+            --pacticipant max-profit-calculator-backend \
+            --latest


### PR DESCRIPTION
## Summary
Enables the `can-i-deploy` compatibility check in the contract tests workflow.

### Changes
- Uncommented the `can-i-deploy` job
- Fixed CLI command: `pact-broker` → `pact broker` (correct subcommand)
- Fixed version selector: `--version=latest` → `--latest` flag
- This check verifies that the latest frontend and backend versions are mutually compatible (a 'can I merge' check)

### Testing
- Tested in GitHub Actions: ✅ All jobs passed
  - frontend-contract-tests ✅
  - backend-contract-tests ✅
  - can-i-deploy ✅ (Computer says yes \o/)