### PR TITLE
fix: remove unused pactbroker.token from PactBrokerVerificationTest

### DIFF
--- a/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
+++ b/src/test/java/com/maxprofit/calculator/PactBrokerVerificationTest.java
@@ -6,21 +6,15 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.Consumer;
 import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
-import au.com.dius.pact.provider.junitsupport.loader.PactBrokerAuth;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 @Provider("max-profit-calculator-backend")
 @Consumer("frontend")
 @PactBroker(
     url = "${pactbroker.host}",
-    authentication = @PactBrokerAuth(token = "${pactbroker.token}"),
     tags = {"latest"}
 )
 public class PactBrokerVerificationTest {


### PR DESCRIPTION
## Summary
Removes the  annotation from the Java Pact test.

Since we switched to a local self-hosted Pact broker (no auth required), the token property is no longer needed. The broker runs on localhost:8080 with no authentication.

**Before:** Required  env var (was missing, causing test failure)
**After:** No auth needed — local broker is open