### PR TITLE
fix(frontend): clear validation banner when user corrects the input

### DIFF
--- a/site/frontend/src/components/CalculatorForm.jsx
+++ b/site/frontend/src/components/CalculatorForm.jsx
@@ -61,6 +61,15 @@ export default function CalculatorForm({ onCalculate, isLoading }) {
     onCalculate({ savings, buyPrices, sellPrices, companyNames });
   };
 
+  const handleSavingsChange = (value) => {
+    setSavings(value);
+    // Clear the validation error when savings is corrected into range,
+    // so the banner doesn't keep shouting after the user fixes the input.
+    if (value >= SAVINGS_MIN && value <= SAVINGS_MAX) {
+      setValidationError(null);
+    }
+  };
+
   const updatePrice = (index, type, value) => {
     const parsed = value === '' ? '' : parseInt(value, 10);
     if (type === 'buy') {
@@ -71,6 +80,12 @@ export default function CalculatorForm({ onCalculate, isLoading }) {
       const next = [...sellPrices];
       next[index] = Number.isNaN(parsed) ? '' : parsed;
       setSellPrices(next);
+    }
+    // Same correction-clears-error behavior as savings: if the resulting
+    // price is in range, drop any stale validation banner.
+    const numeric = Number(parsed);
+    if (!Number.isNaN(numeric) && numeric >= PRICE_MIN && numeric <= PRICE_MAX) {
+      setValidationError(null);
     }
   };
 
@@ -121,7 +136,7 @@ export default function CalculatorForm({ onCalculate, isLoading }) {
           min={SAVINGS_MIN}
           max={SAVINGS_MAX}
           value={savings}
-          onChange={(e) => setSavings(parseInt(e.target.value, 10) || 0)}
+          onChange={(e) => handleSavingsChange(parseInt(e.target.value, 10) || 0)}
           aria-invalid={savings < SAVINGS_MIN || savings > SAVINGS_MAX}
           aria-describedby={validationError ? 'savings-error' : undefined}
           className="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"


### PR DESCRIPTION
## Problem

QA round 2 reported: enter savings=0, click Calculate (red error banner shows), then correct savings to 10 — the banner stays visible even though the input is now valid. Validation state only updated on the next submit.

## Fix

In `CalculatorForm.jsx`:

1. Extracted `handleSavingsChange(value)` from the inline `onChange`. When the new value is within `[SAVINGS_MIN, SAVINGS_MAX]`, it calls `setValidationError(null)`.
2. Same correction-clears-error behavior added to `updatePrice` for buy/sell fields.

The bounds used for clearing are the same `SAVINGS_MIN/MAX` and `PRICE_MIN/MAX` constants that `validate()` uses on submit, so they can't drift out of sync.

## Verification

- `npm run build` — passes
- `npm run test:run` — 1/1 pact contract test passes

## Repro after merge

1. Enter 0 in Savings Amount, click Calculate → banner appears
2. Change savings to 10 → banner disappears immediately
3. Click Calculate → request fires, no error

Same flow works for out-of-range price edits (e.g. type 1500 in a buy cell, error appears; type 50, error disappears).
